### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,8 @@
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {
-    "@octokit/rest": "^21.1.1"
+    "@octokit/rest": "^21.1.1",
+    "js-string-escape": "^1.0.1"
   },
   "type": "commonjs"
 }

--- a/src/issue-details-panel.ts
+++ b/src/issue-details-panel.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import escapeJs from 'js-string-escape';
 import { GitHubAPI } from './github-api';
 
 /**
@@ -270,7 +271,7 @@ export class IssueDetailsPanel {
                         vscode.postMessage({
                             command: 'addComment',
                             issueNumber: ${issue.number},
-                            issueTitle: '${issue.title.replace(/'/g, "\\'")}'
+                            issueTitle: '${escapeJs(issue.title)}'
                         });
                     });
                     
@@ -278,7 +279,7 @@ export class IssueDetailsPanel {
                         vscode.postMessage({
                             command: 'editIssue',
                             issueNumber: ${issue.number},
-                            issueTitle: '${issue.title.replace(/'/g, "\\'")}',
+                            issueTitle: '${escapeJs(issue.title)}',
                             issueState: '${issue.state}'
                         });
                     });
@@ -288,7 +289,7 @@ export class IssueDetailsPanel {
                         vscode.postMessage({
                             command: 'closeIssue',
                             issueNumber: ${issue.number},
-                            issueTitle: '${issue.title.replace(/'/g, "\\'")}',
+                            issueTitle: '${escapeJs(issue.title)}',
                         });
                     });
                     ` : `
@@ -296,7 +297,7 @@ export class IssueDetailsPanel {
                         vscode.postMessage({
                             command: 'reopenIssue',
                             issueNumber: ${issue.number},
-                            issueTitle: '${issue.title.replace(/'/g, "\\'")}',
+                            issueTitle: '${escapeJs(issue.title)}',
                         });
                     });
                     `}


### PR DESCRIPTION
Potential fix for [https://github.com/lgulliver/tech-debt-vscode/security/code-scanning/5](https://github.com/lgulliver/tech-debt-vscode/security/code-scanning/5)

To fix the issue, we need to ensure that backslashes are escaped before escaping single quotes. This can be achieved by chaining two `replace` calls: the first to escape backslashes (`\`) and the second to escape single quotes (`'`). Alternatively, we can use a single regular expression that handles both cases. However, the recommended approach is to use a well-tested sanitization library, such as `he` (for HTML escaping) or `js-string-escape` (for JavaScript string escaping), to ensure robust handling of all edge cases.

In this case, we will use the `js-string-escape` library to escape `issue.title` properly. This library is lightweight and specifically designed for escaping strings in JavaScript code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
